### PR TITLE
Preserve groups collapsed state

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Collections/DataGridGroupDescription.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/DataGridGroupDescription.cs
@@ -149,6 +149,9 @@ namespace Avalonia.Collections
             }
         }
 
+        internal abstract DataGridCollectionViewGroupInternal Parent { get; }
+        internal abstract DataGridGroupDescription GroupBy { get; set; }
+
         protected DataGridCollectionViewGroup(object key)
         {
             Key = key;
@@ -203,7 +206,7 @@ namespace Avalonia.Collections
 
         internal int FullCount { get; set; }
 
-        internal DataGridGroupDescription GroupBy
+        internal override DataGridGroupDescription GroupBy
         {
             get { return _groupBy; }
             set
@@ -283,7 +286,7 @@ namespace Avalonia.Collections
             }
         }
 
-        private DataGridCollectionViewGroupInternal Parent => _parentGroup;
+        internal override DataGridCollectionViewGroupInternal Parent => _parentGroup;
 
         /// <summary>
         /// Adds the specified item to the collection

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -2649,6 +2649,11 @@ namespace Avalonia.Controls
                 // We want to persist selection throughout a reset, so store away the selected items
                 List<object> selectedItemsCache = new List<object>(_selectedItems.SelectedItemsCache);
 
+                var collapsedGroupsCache = RowGroupHeadersTable
+                    .Where(g => !g.Value.IsVisible)
+                    .Select(g => g.Value.CollectionViewGroup.Key)
+                    .ToArray();
+
                 if (recycleRows)
                 {
                     RefreshRows(recycleRows, clearRows: true);
@@ -2656,6 +2661,16 @@ namespace Avalonia.Controls
                 else
                 {
                     RefreshRowsAndColumns(clearRows: true);
+                }
+
+                // collapse previously collapsed groups
+                foreach (var g in collapsedGroupsCache)
+                {
+                    var item = RowGroupHeadersTable.FirstOrDefault(t => t.Value.CollectionViewGroup.Parent.GroupBy.KeysMatch(t.Value.CollectionViewGroup.Key, g));
+                    if (item != null)
+                    {
+                        EnsureRowGroupVisibility(item.Value, false, false);
+                    }
                 }
 
                 // Re-select the old items


### PR DESCRIPTION
This is the same PR as https://github.com/AvaloniaUI/Avalonia/pull/18331


## What does the pull request do?
DataGrid has a Grouping behavior. It has a major flaw: when the collection is Reset or just when the DataGrid control is removed and re-attached to the visual tree, it **forgets the collapsed state of groups.**


## What is the current behavior?
Open the Control catalog DataGrid page.
On the Grouping tab collapse some groups.
Switch tabs back and forth.
Groups are expanded again.

## What is the updated/expected behavior with this PR?
The state is saved and restored

## How was the solution implemented (if it's not obvious)?
I tried to mimick the selection state cache on the same spot.

## Breaking changes
none
