### PR TITLE
Fix Scroll Event Triggering

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -157,21 +157,10 @@ namespace Avalonia.Controls
         // does not know their actual height. The heights used for the approximation are the ones
         // set as the rows were scrolled off.
         private double _verticalOffset;
-        private byte _verticalScrollChangesIgnored;
-        
-        public double VerticalScrollOffset => _verticalOffset;
-        
-        public double HorizontalScrollOffset => _horizontalOffset;        
+        private byte _verticalScrollChangesIgnored;     
         
         public event EventHandler<ScrollEventArgs> HorizontalScroll;
         public event EventHandler<ScrollEventArgs> VerticalScroll;
-
-        /// <summary>
-        /// Cumulated height of all known rows, including the gridlines and details section.
-        /// This property returns an approximation of the actual total row heights and also
-        /// updates the RowHeightEstimate
-        /// </summary>
-        public double RowsTotalHeight => EdgedRowsHeightCalculated;
 
         /// <summary>
         /// Identifies the CanUserReorderColumns dependency property.
@@ -2383,7 +2372,7 @@ namespace Avalonia.Controls
                     handled = true;
                     
                     var eventType = scrollHeight > 0 ? ScrollEventType.SmallIncrement : ScrollEventType.SmallDecrement;
-                    VerticalScroll?.Invoke(this, new ScrollEventArgs(eventType, delta.Y));
+                    VerticalScroll?.Invoke(this, new ScrollEventArgs(eventType, scrollHeight));
                 }
 
                 // Horizontal scroll handling
@@ -2407,8 +2396,8 @@ namespace Avalonia.Controls
                         ignoreInvalidate = true;
                         handled = true;
                         
-                        var eventType = delta.X > 0 ? ScrollEventType.SmallDecrement : ScrollEventType.SmallIncrement;
-                        HorizontalScroll?.Invoke(this, new ScrollEventArgs(eventType, delta.X));
+                        var eventType = horizontalOffset > 0 ? ScrollEventType.SmallDecrement : ScrollEventType.SmallIncrement;
+                        HorizontalScroll?.Invoke(this, new ScrollEventArgs(eventType, horizontalOffset));
                     }
                 }
 

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -2396,7 +2396,7 @@ namespace Avalonia.Controls
                         ignoreInvalidate = true;
                         handled = true;
                         
-                        var eventType = horizontalOffset > 0 ? ScrollEventType.SmallDecrement : ScrollEventType.SmallIncrement;
+                        var eventType = horizontalOffset > 0 ? ScrollEventType.SmallIncrement : ScrollEventType.SmallDecrement;
                         HorizontalScroll?.Invoke(this, new ScrollEventArgs(eventType, horizontalOffset));
                     }
                 }

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -158,9 +158,20 @@ namespace Avalonia.Controls
         // set as the rows were scrolled off.
         private double _verticalOffset;
         private byte _verticalScrollChangesIgnored;
-
+        
+        public double VerticalScrollOffset => _verticalOffset;
+        
+        public double HorizontalScrollOffset => _horizontalOffset;        
+        
         public event EventHandler<ScrollEventArgs> HorizontalScroll;
         public event EventHandler<ScrollEventArgs> VerticalScroll;
+
+        /// <summary>
+        /// Cumulated height of all known rows, including the gridlines and details section.
+        /// This property returns an approximation of the actual total row heights and also
+        /// updates the RowHeightEstimate
+        /// </summary>
+        public double RowsTotalHeight => EdgedRowsHeightCalculated;
 
         /// <summary>
         /// Identifies the CanUserReorderColumns dependency property.

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -2370,6 +2370,9 @@ namespace Avalonia.Controls
                 {
                     DisplayData.PendingVerticalScrollHeight = scrollHeight;
                     handled = true;
+                    
+                    var eventType = scrollHeight > 0 ? ScrollEventType.SmallIncrement : ScrollEventType.SmallDecrement;
+                    VerticalScroll?.Invoke(this, new ScrollEventArgs(eventType, delta.Y));
                 }
 
                 // Horizontal scroll handling
@@ -2392,6 +2395,9 @@ namespace Avalonia.Controls
                         // We don't need to invalidate once again after UpdateHorizontalOffset.
                         ignoreInvalidate = true;
                         handled = true;
+                        
+                        var eventType = delta.X > 0 ? ScrollEventType.SmallDecrement : ScrollEventType.SmallIncrement;
+                        HorizontalScroll?.Invoke(this, new ScrollEventArgs(eventType, delta.X));
                     }
                 }
 

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -157,8 +157,7 @@ namespace Avalonia.Controls
         // does not know their actual height. The heights used for the approximation are the ones
         // set as the rows were scrolled off.
         private double _verticalOffset;
-        private byte _verticalScrollChangesIgnored;     
-        
+        private byte _verticalScrollChangesIgnored;
         public event EventHandler<ScrollEventArgs> HorizontalScroll;
         public event EventHandler<ScrollEventArgs> VerticalScroll;
 

--- a/src/DataGridSample/DataGridSample.csproj
+++ b/src/DataGridSample/DataGridSample.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.2.5" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
   </ItemGroup>

--- a/src/DataGridSample/DataGridSample.csproj
+++ b/src/DataGridSample/DataGridSample.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.2.5" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
   </ItemGroup>

--- a/src/DataGridSample/MainWindow.axaml.cs
+++ b/src/DataGridSample/MainWindow.axaml.cs
@@ -1,5 +1,4 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 
 namespace DataGridSample;
 
@@ -8,8 +7,5 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
-#if DEBUG
-        this.AttachDevTools();
-#endif
     }
 }

--- a/src/DataGridSample/MainWindow.axaml.cs
+++ b/src/DataGridSample/MainWindow.axaml.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls;
+﻿using Avalonia;
+using Avalonia.Controls;
 
 namespace DataGridSample;
 
@@ -7,5 +8,8 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+#if DEBUG
+        this.AttachDevTools();
+#endif
     }
 }


### PR DESCRIPTION
## What does the pull request do?
This PR fixes a bug that caused the HorizontalScroll and VerticalScroll events not to be triggered using the pointer wheel, and also adds access to private properties that can be used to implement IsScrolledtoBottom and other things.

## What is the current behavior?
The Vertical Scroll and Horizontal Scroll events are triggered when using ScrollBar.

## What is the updated/expected behavior with this PR?
The Vertical Scroll and Horizontal Scroll events are triggered when using ScrollBar or pointer wheel.

## Checklist
- [ ] Fixed the issue of non-functioning of vertical and horizontal scrolling events
- [ ] Added ScrollOffset and RowsTotalHeight properties