### PR TITLE
Restore CI build

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -247,5 +247,10 @@ indent_size = 2
 # Shell scripts
 [*.sh]
 end_of_line = lf
+
 [*.{cmd,bat}]
 end_of_line = crlf
+
+# YAML config files
+[*.{yaml,yml}]
+indent_size = 2

--- a/Avalonia.Controls.DataGrid.sln
+++ b/Avalonia.Controls.DataGrid.sln
@@ -8,6 +8,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		build\SharedVersion.props = build\SharedVersion.props
 		licence.md = licence.md
 		readme.md = readme.md
+		azure-pipelines.yml = azure-pipelines.yml
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Avalonia.Controls.DataGrid.UnitTests", "src\Avalonia.Controls.DataGrid.UnitTests\Avalonia.Controls.DataGrid.UnitTests.csproj", "{91F13463-94A3-4635-96A2-EBB8A7D899DA}"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,46 @@
+pool:
+  vmImage: ubuntu-latest
+
+variables:
+  configuration: 'Release'
+  lowerConfiguration: '${{ lower(variables.configuration) }}'
+  versionSuffix: ''
+  commonDotNetParameters: '--invalid-will-be-replaced'
+
+steps:
+
+- task: PowerShell@2
+  displayName: 'Set non-release version suffix'
+  condition: not(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))
+  inputs:
+    targetType: 'inline'
+    script: |
+      $versionSuffix = "-cibuild{0:D7}-alpha" -f $(Build.BuildId)
+      Write-Output "Setting versionSuffix to '$versionSuffix'"
+      Write-Output "##vso[task.setvariable variable=versionSuffix]$versionSuffix"
+
+- script: echo "##vso[task.setvariable variable=commonDotNetParameters]-c $(configuration) -p:CIBranchName='$(Build.SourceBranchName)' -p:CIVersionSuffix='$(versionSuffix)'"
+  displayName: 'Set variables'
+
+- script: dotnet build $(commonDotNetParameters) --no-incremental
+  displayName: 'Build solution'
+
+- script: dotnet test $(commonDotNetParameters) --logger trx --results-directory "artifacts/test/$(lowerConfiguration)" --no-build
+  displayName: 'Run tests'
+
+- script: dotnet pack $(commonDotNetParameters) --no-build
+  displayName: 'Create package'
+
+- task: PublishTestResults@2
+  displayName: 'Publish test results'
+  inputs:
+    testResultsFormat: 'VSTest'
+    testResultsFiles: 'artifacts/test/$(lowerConfiguration)/*.trx'
+  condition: not(canceled())
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish package'
+  inputs:
+    PathtoPublish: '$(Build.SourcesDirectory)/artifacts/package/$(lowerConfiguration)/'
+    ArtifactName: 'drop'
+    publishLocation: 'Container'

--- a/build/SharedVersion.props
+++ b/build/SharedVersion.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <Product>Avalonia</Product>
-    <Version>$(AvaloniaVersion)</Version>
+    <Version>11.2.999$(CIVersionSuffix)</Version>
     <Authors>Avalonia Team</Authors>
     <Copyright>Copyright 2013-$([System.DateTime]::Now.ToString(`yyyy`)) &#169; The AvaloniaUI Project</Copyright>
     <PackageProjectUrl>https://avaloniaui.net/?utm_source=nuget&amp;utm_medium=referral&amp;utm_content=project_homepage_link</PackageProjectUrl>
@@ -13,14 +13,16 @@
     <PackageIcon>Icon.png</PackageIcon>
     <PackageDescription>Avalonia is a cross-platform UI framework for .NET providing a flexible styling system and supporting a wide range of Operating Systems such as Windows, Linux, macOS and with experimental support for Android, iOS and WebAssembly.</PackageDescription>
     <PackageTags>avalonia;avaloniaui;mvvm;rx;reactive extensions;android;ios;mac;forms;wpf;net;netstandard;net461;uwp;xamarin</PackageTags>
-    <PackageReleaseNotes>https://github.com/AvaloniaUI/Avalonia/releases</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/AvaloniaUI/Avalonia.Controls.DataGrid/releases</PackageReleaseNotes>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
     <RepositoryType>git</RepositoryType>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)/avalonia.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
-  <ItemGroup Label="PackageIcon">
-    <None Include="$(MSBuildThisFileDirectory)/Assets/Icon.png" Pack="true" Visible="false" PackagePath=""/>
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)/../readme.md" Pack="true" PackagePath="/" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)/Assets/Icon.png" Pack="true" PackagePath="/" Visible="false"/>
   </ItemGroup>
 
 </Project>

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,15 @@
 [![NuGet](https://img.shields.io/nuget/v/Avalonia.Controls.DataGrid.svg)](https://www.nuget.org/packages/Avalonia.Controls.DataGrid/)
 
-# Avalonia `DataGrid`
+# Avalonia DataGrid
+
+## About
+
+The official `DataGrid` control for [Avalonia](https://github.com/AvaloniaUI/Avalonia).  
+
+It displays repeating data in a customizable grid.  
+See the [documentation](https://docs.avaloniaui.net/docs/reference/controls/datagrid/) for more information.
+
+## Status
 
 The `DataGrid` control was initially ported from Silverlight, and was previously part of the [Avalonia main repository](https://github.com/AvaloniaUI/Avalonia).  
-It now lives in the current repository: see [this discussion](https://github.com/AvaloniaUI/Avalonia/discussions/18388) for details.
+It now lives in its [own repository](https://github.com/AvaloniaUI/Avalonia.Controls.DataGrid): see [this discussion](https://github.com/AvaloniaUI/Avalonia/discussions/18388) for details.

--- a/release.md
+++ b/release.md
@@ -1,0 +1,20 @@
+﻿# Release instructions
+
+## Branch and Tag
+
+1. Create a branch named `release/<version>` (e.g. `release/11.2.6`) for a specific version.
+2. Update the version in `SharedVersion.props`, e.g. `<Version>11.2.6</Version>` 
+3. Add a matching tag for this version, e.g. `git tag -a 11.2.6`
+4. Push the release branch and the tag.
+
+## CI Build
+
+5. Wait for Azure Pipelines to finish the build. A matching build in the `nuget-feed-all` feed should be released soon after.
+6. Using the build, run a due diligence test to make sure you're happy with the package.
+7. On Azure Pipelines, on the build for your release, click on the badge for *NuGet (Release!)* then click on *Deploy*.
+
+## GitHub Release
+
+8. Make a new release on GitHub releases.
+9. Select the tag matching the version, then click on *Generate release notes*. 
+10. Review the release information, then click on *Publish release*.

--- a/src/Avalonia.Controls.DataGrid.UnitTests/Avalonia.Controls.DataGrid.UnitTests.csproj
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/Avalonia.Controls.DataGrid.UnitTests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>$(AvsCurrentTargetFramework)</TargetFramework>
     <OutputType>Library</OutputType>
     <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <RootNamespace>Avalonia.Controls.DataGridTests</RootNamespace>
   </PropertyGroup>

--- a/src/Avalonia.Controls.DataGrid.UnitTests/LeakTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/LeakTests.cs
@@ -21,11 +21,11 @@ public class LeakTests
         DotMemoryUnitTestOutput.SetOutputMethod(output.WriteLine);
     }
 
-    [Fact]
+    [Fact(Skip = "Run with dotMemory")]
     [SuppressMessage("Usage", "xUnit1031:Do not use blocking task operations in test method", Justification = "Needed for dotMemoryUnit to work")]
     public void DataGrid_Is_Freed()
     {
-        // When attached to INotifyCollectionChanged, DataGrid will subscribe to it's events, potentially causing leak
+        // When attached to INotifyCollectionChanged, DataGrid will subscribe to its events, potentially causing leak
         var run = async () =>
         {
             using var session = HeadlessUnitTestSession.StartNew(typeof(Application));

--- a/src/Avalonia.Controls.DataGrid/Avalonia.Controls.DataGrid.csproj
+++ b/src/Avalonia.Controls.DataGrid/Avalonia.Controls.DataGrid.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>$(AvsCurrentTargetFramework);$(AvsLegacyTargetFrameworks);netstandard2.0</TargetFrameworks>
+    <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
@@ -21,5 +22,31 @@
   </ItemGroup>
 
   <Import Project="../../build/SharedVersion.props" />
+
+  <Target Name="UpdateCIBuildNumber"
+          BeforeTargets="PreBuildEvent"
+          Condition="'$(TargetFramework)' == '$(AvsCurrentTargetFramework)' And '$(CIBranchName)' != ''">
+
+    <Message Text="##vso[build.updatebuildnumber]$(Version)"
+             Importance="high" />
+
+  </Target>
+
+  <Target Name="VerifyCIBranch"
+          BeforeTargets="PreBuildEvent"
+          Condition="'$(CIBranchName)' != ''">
+
+    <Message Text="Building non-release version $(Version) for $(TargetFramework)"
+             Condition="'$(CIVersionSuffix)' != ''"
+             Importance="high" />
+
+    <Message Text="Building RELEASE version $(Version) for $(TargetFramework)"
+             Condition="'$(CIVersionSuffix)' == ''"
+             Importance="high" />
+
+    <Error Text="Current release branch '$(CIBranchName)' does not match version '$(Version)'!"
+           Condition="'$(CIVersionSuffix)' == '' And '$(CIBranchName)' != '$(Version)'" />
+
+  </Target>
 
 </Project>

--- a/src/DataGridSample/DataGridSample.csproj
+++ b/src/DataGridSample/DataGridSample.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>$(AvsCurrentTargetFramework)</TargetFramework>
+    <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>


### PR DESCRIPTION
This PR adds back an `azure-pipelines.yml` file, used to trigger the build on Azure DevOps.
Some release instructions have also been added.