### PR TITLE
Null Check DataGridTemplateColumn Parent Element in RefreshCellContent

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridTemplateColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridTemplateColumn.cs
@@ -123,7 +123,7 @@ namespace Avalonia.Controls
 
         protected internal override void RefreshCellContent(Control element, string propertyName)
         {
-            var cell = element.Parent as DataGridCell;
+            var cell = element?.Parent as DataGridCell;
             if(propertyName == nameof(CellTemplate) && cell is not null)
             {
                 cell.Content = GenerateElement(cell, cell.DataContext);


### PR DESCRIPTION
A null `DataGridTemplateColumn` would normally result in either nothing appearing in the designer, or a not implemented exception at runtime, since there is nothing to render. However, if you add a `DataGridTemplateColumn` with a null template, and click on the data grid header while in design mode, you can get a NRE in the `RefreshCellContent` method that breaks the designer.

```
Initializing application in design mode
Obtaining AppBuilder instance from ATRepo.Program
Sending StartDesignerSessionMessage
Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at Avalonia.Controls.DataGridTemplateColumn.RefreshCellContent(Control element, String propertyName)
   at Avalonia.Controls.DataGridRow.OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
   at Avalonia.Animation.Animatable.OnPropertyChangedCore(AvaloniaPropertyChangedEventArgs change)
   at Avalonia.PropertyStore.EffectiveValue`1.NotifyValueChanged(ValueStore owner, StyledProperty`1 property, T oldValue)
   at Avalonia.PropertyStore.EffectiveValue`1.SetAndRaiseCore(ValueStore owner, StyledProperty`1 property, T value, BindingPriority priority, Boolean isOverriddenCurrentValue, Boolean I...
```

```xml
<UserControl xmlns="https://github.com/avaloniaui"
             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
             xmlns:heroIcons="clr-namespace:HeroIconsAvalonia.Controls;assembly=HeroIconsAvalonia"
             xmlns:viewModel="clr-namespace:ATRepo.ViewModel"
             xmlns:lexicon="clr-namespace:FishyFlip.Lexicon;assembly=FishyFlip"
             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
             x:DataType="viewModel:ATRecordGridViewModel"
             x:Class="ATRepo.Views.ATRecordGrid">
    <Design.DataContext>    
        <viewModel:DesignATRecordGridViewModel/>
    </Design.DataContext>
    <StackPanel>
        <DataGrid 
            HeadersVisibility="Column"
            IsReadOnly="True"
            ItemsSource="{Binding Posts}" 
            BorderThickness="1" 
            BorderBrush="Gray" 
            GridLinesVisibility="All">
            <DataGrid.Columns>
                <DataGridTextColumn Header="Type" Width="*" 
                                    Binding="{Binding Type}"/>
                <DataGridTemplateColumn Header="Open">
                  
                </DataGridTemplateColumn>
            </DataGrid.Columns>
        </DataGrid>
    </StackPanel>
</UserControl>
```

<img width="1113" alt="スクリーンショット 2025-05-19 21 25 04" src="https://github.com/user-attachments/assets/ee36f2b1-4977-4aff-b486-cd733d57e94f" />

<img width="1095" alt="スクリーンショット 2025-05-19 21 25 10" src="https://github.com/user-attachments/assets/048ba077-1966-44ba-9c0c-5ecde364739b" />

This PR fixes it by adding a null check for the element. This should keep the designer working even if you click or interact with the DataGrid.
