### PR TITLE
Fixes #196 for a possible NRE

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
@@ -149,8 +149,7 @@ namespace Avalonia.Controls
         {
             get
             {
-                Debug.Assert(OwningGrid != null);
-                return (RowGroupInfo.Slot == OwningGrid.CurrentSlot);
+                return RowGroupInfo.Slot == OwningGrid?.CurrentSlot;
             }
         }
 


### PR DESCRIPTION
This is a fix for a possible NRE that can occur `IsCurrent` is called. Before this change the property `IsCurrent` never checks the nullability. Now it does.