### PR TITLE
Update version to 12.0.999

### DIFF
--- a/build/SharedVersion.props
+++ b/build/SharedVersion.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <Product>Avalonia</Product>
-    <Version>11.3.999$(CIVersionSuffix)</Version>
+    <Version>12.0.999$(CIVersionSuffix)</Version>
     <Authors>Avalonia Team</Authors>
     <Copyright>Copyright 2013-$([System.DateTime]::Now.ToString(`yyyy`)) &#169; The AvaloniaUI Project</Copyright>
     <PackageProjectUrl>https://avaloniaui.net/?utm_source=nuget&amp;utm_medium=referral&amp;utm_content=project_homepage_link</PackageProjectUrl>


### PR DESCRIPTION
The main branch now targets Avalonia 12, update the version accordingly.