### PR TITLE
Update Avalonia to 12.0.999-cibuild0062021

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <AvsCurrentTargetFramework>net10.0</AvsCurrentTargetFramework>
     <AvsLegacyTargetFrameworks>net8.0</AvsLegacyTargetFrameworks>
     <LangVersion>12.0</LangVersion>
-    <AvaloniaVersion>12.0.999-cibuild0061769-alpha</AvaloniaVersion>
+    <AvaloniaVersion>12.0.999-cibuild0062021-alpha</AvaloniaVersion>
     <AvaloniaPublicKey>0024000004800000940000000602000000240000525341310004000001000100c1bba1142285fe0419326fb25866ba62c47e6c2b5c1ab0c95b46413fad375471232cb81706932e1cef38781b9ebd39d5100401bacb651c6c5bbf59e571e81b3bc08d2a622004e08b1a6ece82a7e0b9857525c86d2b95fab4bc3dce148558d7f3ae61aa3a234086902aeface87d9dfdd32b9d2fe3c6dd4055b5ab4b104998bd87</AvaloniaPublicKey>
   </PropertyGroup>
 </Project>

--- a/src/Avalonia.Controls.DataGrid.UnitTests/DataGridRowTests.cs
+++ b/src/Avalonia.Controls.DataGrid.UnitTests/DataGridRowTests.cs
@@ -159,7 +159,7 @@ public class DataGridRowTests
     {
         return new Style(x => x.OfType<DataGridRow>())
         {
-            Setters = { new Setter(DataGridRow.IsSelectedProperty, new Binding("IsSelected", BindingMode.TwoWay)) }
+            Setters = { new Setter(DataGridRow.IsSelectedProperty, new Binding("IsSelected") { Mode = BindingMode.TwoWay } ) }
         };
     }
 
@@ -167,7 +167,7 @@ public class DataGridRowTests
     {
         return new Style(x => x.OfType<DataGridRow>())
         {
-            Setters = { new Setter(DataGridRow.HeaderProperty, new Binding("Name", BindingMode.OneWay))} 
+            Setters = { new Setter(DataGridRow.HeaderProperty, new Binding("Name") { Mode = BindingMode.OneWay } )} 
         };
     }
 


### PR DESCRIPTION
Hi,

I'm having a go at [updating Avalonia.FuncUI to Avalonia 12](https://github.com/fsprojects/Avalonia.FuncUI/pull/476) and as it stands with the latest versions of things, the DataGrid sample application crashes at runtime with 

```
Unhandled exception. System.MissingMethodException: Method not found: 'System.IDisposable Avalonia.AvaloniaObjectExtensions.Bind(Avalonia.AvaloniaObject, Avalonia.AvaloniaProperty, Avalonia.Data.BindingBase, System.Object)'.
```
And I believe the method in question was removed in https://github.com/AvaloniaUI/Avalonia/pull/20613.

Rebuilding DataGrid with a newer version of Avalonia seems to fix this error for me locally anyway.

Thanks.
