### PR TITLE
Remove usages of internal Avalonia APIs

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.cs
@@ -2625,7 +2625,7 @@ namespace Avalonia.Collections
         /// <returns>Whether the specified flag is set</returns>
         private bool CheckFlag(CollectionViewFlags flags)
         {
-            return _flags.HasAllFlags(flags);
+            return (_flags & flags) == flags;
         }
 
         /// <summary>

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -2236,22 +2236,6 @@ namespace Avalonia.Controls
             return desiredSize;
         }
 
-        /// <inheritdoc/>
-        protected override void OnDataContextBeginUpdate()
-        {
-            base.OnDataContextBeginUpdate();
-
-            NotifyDataContextPropertyForAllRowCells(GetAllRows(), true);
-        }
-
-        /// <inheritdoc/>
-        protected override void OnDataContextEndUpdate()
-        {
-            base.OnDataContextEndUpdate();
-
-            NotifyDataContextPropertyForAllRowCells(GetAllRows(), false);
-        }
-
         /// <summary>
         /// Raises the BeginningEdit event.
         /// </summary>
@@ -3280,20 +3264,6 @@ namespace Avalonia.Controls
             }
         }
 
-        private static void NotifyDataContextPropertyForAllRowCells(IEnumerable<DataGridRow> rowSource, bool arg2)
-        {
-            foreach (DataGridRow row in rowSource)
-            {
-                foreach (DataGridCell cell in row.Cells)
-                {
-                    if (cell.Content is StyledElement cellContent)
-                    {
-                        DataContextProperty.Notifying?.Invoke(cellContent, arg2);
-                    }
-                }
-            }
-        }
-
         private void UpdateRowDetailsVisibilityMode(DataGridRowDetailsVisibilityMode newDetailsMode)
         {
             int itemCount = DataConnection.Count;
@@ -4021,7 +3991,7 @@ namespace Avalonia.Controls
             {
                 bool focusLeftDataGrid = true;
                 bool dataGridWillReceiveRoutedEvent = true;
-                Visual focusedObject = FocusManager.GetFocusManager(this)?.GetFocusedElement() as Visual;
+                var focusedObject = TopLevel.GetTopLevel(this)?.FocusManager?.GetFocusedElement() as Visual;
                 DataGridColumn editingColumn = null;
 
                 while (focusedObject != null)
@@ -4911,7 +4881,7 @@ namespace Avalonia.Controls
             if (!ctrl)
             {
                 // If Enter was used by a TextBox, we shouldn't handle the key
-                if (FocusManager.GetFocusManager(this)?.GetFocusedElement() is TextBox focusedTextBox
+                if (TopLevel.GetTopLevel(this)?.FocusManager?.GetFocusedElement() is TextBox focusedTextBox
                     && focusedTextBox.AcceptsReturn)
                 {
                     return false;
@@ -6116,7 +6086,7 @@ namespace Avalonia.Controls
         /// <returns>The formatted string.</returns>
         private string FormatClipboardContent(DataGridRowClipboardEventArgs e)
         {
-            var text = StringBuilderCache.Acquire();
+            var text = new StringBuilder();
             var clipboardRowContent = e.ClipboardRowContent;
             var numberOfItem = clipboardRowContent.Count;
             for (int cellIndex = 0; cellIndex < numberOfItem; cellIndex++)
@@ -6134,7 +6104,7 @@ namespace Avalonia.Controls
                     text.Append('\n');
                 }
             }
-            return StringBuilderCache.GetStringAndRelease(text);
+            return text.ToString();
         }
 
         /// <summary>
@@ -6149,7 +6119,7 @@ namespace Avalonia.Controls
 
             if (ctrl && !shift && !alt && ClipboardCopyMode != DataGridClipboardCopyMode.None && SelectedItems.Count > 0)
             {
-                var textBuilder = StringBuilderCache.Acquire();
+                var textBuilder = new StringBuilder();
 
                 if (ClipboardCopyMode == DataGridClipboardCopyMode.IncludeHeader)
                 {
@@ -6175,7 +6145,7 @@ namespace Avalonia.Controls
                     textBuilder.Append(FormatClipboardContent(itemArgs));
                 }
 
-                string text = StringBuilderCache.GetStringAndRelease(textBuilder);
+                string text = textBuilder.ToString();
 
                 if (!string.IsNullOrEmpty(text))
                 {

--- a/src/Avalonia.Controls.DataGrid/DataGridRow.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRow.cs
@@ -18,7 +18,6 @@ using Avalonia.VisualTree;
 using System;
 using System.Diagnostics;
 using Avalonia.Automation.Peers;
-using Avalonia.Reactive;
 using Avalonia.Automation;
 
 namespace Avalonia.Controls
@@ -1034,19 +1033,16 @@ namespace Avalonia.Controls
                         {
                             layoutableContent.LayoutUpdated += DetailsContent_LayoutUpdated;
 
-                            _detailsContentSizeSubscription = new CompositeDisposable(2)
-                            {
-                                Disposable.Create(() => layoutableContent.LayoutUpdated -= DetailsContent_LayoutUpdated),
+                            _detailsContentSizeSubscription = new CompositeDisposable(
+                            [
+                                new ActionDisposable(() => layoutableContent.LayoutUpdated -= DetailsContent_LayoutUpdated),
                                 _detailsContent.GetObservable(MarginProperty).Subscribe(DetailsContent_MarginChanged)
-                            };
-
-
+                            ]);
                         }
                         else
                         {
                             _detailsContentSizeSubscription =
-                                _detailsContent.GetObservable(MarginProperty)
-                                               .Subscribe(DetailsContent_MarginChanged);
+                                _detailsContent.GetObservable(MarginProperty).Subscribe(DetailsContent_MarginChanged);
 
                         }
 

--- a/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
@@ -11,9 +11,8 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Media;
 using System;
-using System.Diagnostics;
+using Avalonia.Controls.Utils;
 using Avalonia.LogicalTree;
-using Avalonia.Reactive;
 
 namespace Avalonia.Controls
 {

--- a/src/Avalonia.Controls.DataGrid/DataGridRows.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRows.cs
@@ -17,6 +17,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using Avalonia.Data;
+using Avalonia.Layout;
 using Avalonia.Styling;
 
 namespace Avalonia.Controls
@@ -2564,7 +2565,7 @@ namespace Avalonia.Controls
                             double heightChange = UpdateRowGroupVisibility(rowGroupInfo, isVisible, isDisplayed: false);
                             // Use epsilon instead of 0 here so that in the off chance that our estimates put the vertical offset negative
                             // the user can still scroll to the top since the offset is non-zero
-                            SetVerticalOffset(Math.Max(MathUtilities.DoubleEpsilon, _verticalOffset + heightChange));
+                            SetVerticalOffset(Math.Max(LayoutHelper.LayoutEpsilon, _verticalOffset + heightChange));
                         }
                         else
                         {

--- a/src/Avalonia.Controls.DataGrid/Utils/ActionDisposable.cs
+++ b/src/Avalonia.Controls.DataGrid/Utils/ActionDisposable.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Threading;
+
+namespace Avalonia.Controls.Utils;
+
+internal sealed class ActionDisposable(Action dispose) : IDisposable
+{
+    private Action? _dispose = dispose;
+
+    public void Dispose()
+        => Interlocked.Exchange(ref _dispose, null)?.Invoke();
+}

--- a/src/Avalonia.Controls.DataGrid/Utils/AnonymousObserver.cs
+++ b/src/Avalonia.Controls.DataGrid/Utils/AnonymousObserver.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Avalonia.Controls.Utils;
+
+internal sealed class AnonymousObserver<T>(Action<T> onNext, Action<Exception>? onError, Action? onCompleted) : IObserver<T>
+{
+    public void OnNext(T value)
+        => onNext.Invoke(value);
+
+    public void OnError(Exception error)
+    {
+        if (onError is not null)
+            onError(error);
+        else
+            throw error;
+    }
+
+    public void OnCompleted()
+        => onCompleted?.Invoke();
+}

--- a/src/Avalonia.Controls.DataGrid/Utils/CompositeDisposable.cs
+++ b/src/Avalonia.Controls.DataGrid/Utils/CompositeDisposable.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Threading;
+
+namespace Avalonia.Controls.Utils;
+
+internal sealed class CompositeDisposable(IDisposable[] disposables) : IDisposable
+{
+    private IDisposable[]? _disposables = disposables;
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposables, null) is { } disposables)
+        {
+            foreach (var disposable in disposables)
+                disposable.Dispose();
+        }
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Utils/ObservableExtensions.cs
+++ b/src/Avalonia.Controls.DataGrid/Utils/ObservableExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Avalonia.Controls.Utils;
+
+internal static class ObservableExtensions
+{
+    public static IDisposable Subscribe<T>(this IObservable<T> source, Action<T> action)
+        => source.Subscribe(new AnonymousObserver<T>(action, null, null));
+
+    public static IObservable<T> Skip<T>(this IObservable<T> source, int skipCount)
+        => new SkipObservable<T>(source, skipCount);
+}

--- a/src/Avalonia.Controls.DataGrid/Utils/SkipObservable.cs
+++ b/src/Avalonia.Controls.DataGrid/Utils/SkipObservable.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Avalonia.Controls.Utils;
+
+internal sealed class SkipObservable<T>(IObservable<T> source, int skipCount) : IObservable<T>
+{
+    public IDisposable Subscribe(IObserver<T> observer)
+    {
+        var remaining = skipCount;
+
+        return source.Subscribe(new AnonymousObserver<T>(
+            value =>
+            {
+                if (remaining <= 0)
+                    observer.OnNext(value);
+                else
+                    --remaining;
+            },
+            observer.OnError,
+            observer.OnCompleted));
+    }
+}

--- a/src/Avalonia.Controls.DataGrid/Utils/TreeHelper.cs
+++ b/src/Avalonia.Controls.DataGrid/Utils/TreeHelper.cs
@@ -36,7 +36,7 @@ namespace Avalonia.Controls.Utils
                     {
                         if (child is Control childElement)
                         {
-                            parent = childElement.VisualParent;
+                            parent = childElement.GetVisualParent();
                         }
                     }
                     child = parent;


### PR DESCRIPTION
This PR removes the usage of internal Avalonia APIs. The goal is to remove the `InternalsVisibleTo` attribute from the main repository:
 - A few reactive extensions have been ported, with simplified versions.
 - The `NotifyDataContextPropertyForAllRowCells` method has been completely deleted. Its implementation made no sense as data context notifications happen naturally in the core framework.
