### PR TITLE
Feature/column autofit on double click

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
@@ -96,6 +96,7 @@ namespace Avalonia.Controls
             PointerMoved += DataGridColumnHeader_PointerMoved;
             PointerEntered += DataGridColumnHeader_PointerEntered;
             PointerExited += DataGridColumnHeader_PointerExited;
+            DoubleTapped += DataGridColumnHeader_DoubleTapped;
         }
 
         protected override AutomationPeer OnCreateAutomationPeer()
@@ -533,6 +534,66 @@ namespace Avalonia.Controls
             Point mousePositionHeaders = e.GetPosition(OwningGrid.ColumnHeaders);
 
             OnMouseMove(e, mousePosition, mousePositionHeaders);
+        }
+
+        private void DataGridColumnHeader_DoubleTapped(object sender, TappedEventArgs e)
+        {
+            if (OwningColumn == null || OwningGrid == null || !IsEnabled || e.Handled)
+            {
+                return;
+            }
+
+            Point mousePosition = e.GetPosition(this);
+            double distanceFromLeft = mousePosition.X;
+            double distanceFromRight = Bounds.Width - distanceFromLeft;
+
+            DataGridColumn columnToAutoFit = null;
+
+            if (distanceFromRight <= DATAGRIDCOLUMNHEADER_resizeRegionWidth)
+            {
+                // Right edge of header — auto-fit this column
+                columnToAutoFit = OwningColumn;
+            }
+            else if (distanceFromLeft <= DATAGRIDCOLUMNHEADER_resizeRegionWidth)
+            {
+                // Left edge of header — auto-fit the column to the left
+                if (!(OwningColumn is DataGridFillerColumn))
+                {
+                    columnToAutoFit = OwningGrid.ColumnsInternal.GetPreviousVisibleNonFillerColumn(OwningColumn);
+                }
+            }
+
+            if (columnToAutoFit == null || !CanResizeColumn(columnToAutoFit))
+            {
+                return;
+            }
+
+            AutoFitColumnWidth(columnToAutoFit);
+            e.Handled = true;
+        }
+
+        /// <summary>
+        /// Auto-fits a column's width to its content by temporarily switching to Auto sizing,
+        /// allowing the DataGrid to measure all visible cells and the header, then locking the
+        /// resulting width to a fixed pixel value.
+        /// </summary>
+        private static void AutoFitColumnWidth(DataGridColumn column)
+        {
+            var oldWidth = column.Width;
+
+            // Reset the desired width so the column will be fully re-measured during the next layout pass.
+            column.SetWidthInternalNoCallback(
+                new DataGridLength(oldWidth.Value, DataGridLengthUnitType.Auto, double.NaN, oldWidth.DisplayValue));
+
+            // After the layout pass completes, lock the measured width to a fixed pixel value
+            // so subsequent manual drag-resizing works predictably.
+            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+            {
+                double measuredWidth = Math.Max(column.ActualMinWidth, Math.Min(column.ActualMaxWidth, column.ActualWidth));
+                column.SetWidthInternalNoCallback(
+                    new DataGridLength(measuredWidth, DataGridLengthUnitType.Pixel, measuredWidth, measuredWidth));
+                column.OwningGrid?.OnColumnWidthChanged(column);
+            }, Avalonia.Threading.DispatcherPriority.Loaded);
         }
 
         /// <summary>


### PR DESCRIPTION
# Auto-fit column width on double-click of resize grip

## What

Adds the standard "double-click column separator to auto-fit" behavior to `DataGridColumnHeader`, matching WPF's `DataGrid`.

**Before:** Double-clicking the resize grip does nothing (or triggers sort on the adjacent header).
**After:** Double-clicking the resize grip auto-sizes the column to fit its header and visible cell content.

## How

Single addition to `DataGridColumnHeader.cs` (~60 lines, no API surface changes):

1. New `DoubleTapped` handler in the constructor
2. Uses the existing `DATAGRIDCOLUMNHEADER_resizeRegionWidth` constant for grip detection — right edge fits that column, left edge fits the column to the left
3. Respects `CanResizeColumn()` (both grid-level and column-level settings)
4. Temporarily sets `Auto` sizing via `SetWidthInternalNoCallback` to trigger content measurement, then locks to a fixed pixel width via `Dispatcher.Post` for predictable subsequent drag behavior
5. Respects `ActualMinWidth` / `ActualMaxWidth` constraints

## Why

This is standard behavior in WPF `DataGrid`, WinForms `DataGridView`, Excel, and virtually every desktop grid control. Users coming from any of these environments instinctively double-click column separators to auto-fit. I searched the Avalonia and Avalonia.Controls.DataGrid issue trackers and found no prior feature request.

We implemented an [external workaround](https://github.com/HannahVernon/SqlServerAgMonitor/blob/dev/src/SqlAgMonitor/Helpers/DataGridAutoFitHelper.cs) for our project, but it has limitations (string-based column matching since `OwningColumn` is internal, estimated grip zone, layout timing hacks). This native implementation avoids all of those by using internal APIs directly.

## Testing

- All 20 existing unit tests pass
- Manually verified in our Avalonia 11.x app via the external workaround using the same approach
