### PR TITLE
Fix DataGrid not updating on collection Move operations

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.cs
@@ -3445,45 +3445,46 @@ namespace Avalonia.Collections
 
             if (args.Action == NotifyCollectionChangedAction.Move)
             {
-                int itemCount = args.OldItems?.Count ?? 0;
-                if (args.NewStartingIndex >= args.OldStartingIndex &&
-                    args.NewStartingIndex <= args.OldStartingIndex + itemCount - 1)
+                if (args.OldItems is not { } oldItems || args.NewItems is not { } newItems)
                 {
                     return;
                 }
-
-                if (args.OldItems != null)
+                
+                int itemCount = oldItems.Count;
+                if (args.NewStartingIndex >= args.OldStartingIndex &&
+                    args.NewStartingIndex <= args.OldStartingIndex + itemCount - 1)
                 {
-                    foreach (var removedItem in args.OldItems)
+                    // the target index for the move is within the items being moved, do nothing
+                    return;
+                }
+
+                foreach (var removedItem in oldItems)
+                {
+                    ProcessRemoveEvent(removedItem, true);
+                }
+
+                int insertIndex;
+                int count = newItems.Count;
+                if (args.NewStartingIndex > args.OldStartingIndex)
+                {
+                    // item(s) are being moved down
+                    insertIndex = args.NewStartingIndex - count + 1;
+                }
+                else
+                {
+                    // item(s) are being moved up
+                    insertIndex = args.NewStartingIndex;
+                }
+
+                for (var i = 0; i < count; i++)
+                {
+                    var item = newItems[i];
+                    if (Filter == null || PassesFilter(item))
                     {
-                        ProcessRemoveEvent(removedItem, true);
+                        ProcessAddEvent(item, insertIndex + i);
                     }
                 }
 
-                if (args.NewItems != null)
-                {
-                    int insertIndex;
-                    int count = args.NewItems.Count;
-                    if (args.NewStartingIndex > args.OldStartingIndex)
-                    {
-                        // item(s) are being moved down
-                        insertIndex = args.NewStartingIndex - count + 1;
-                    }
-                    else
-                    {
-                        // item(s) are being moved up
-                        insertIndex = args.NewStartingIndex;
-                    }
-
-                    for (var i = 0; i < count; i++)
-                    {
-                        var item = args.NewItems[i];
-                        if (Filter == null || PassesFilter(item))
-                        {
-                            ProcessAddEvent(item, insertIndex + i);
-                        }
-                    }
-                }
                 return;
             }
 

--- a/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.cs
@@ -3442,24 +3442,65 @@ namespace Avalonia.Collections
                 RefreshOrDefer();
                 return;
             }
-            
+
+            if (args.Action == NotifyCollectionChangedAction.Move)
+            {
+                if (args.OldItems != null)
+                {
+                    foreach (var removedItem in args.OldItems)
+                    {
+                        ProcessRemoveEvent(removedItem, true);
+                    }
+                }
+
+                if (args.NewItems != null)
+                {
+                    // Compute the correct insertion index in _internalList after
+                    // the moved items have been removed. args.NewStartingIndex is
+                    // in the original list's index space, so we adjust based on
+                    // the direction of the move.
+                    int insertIndex;
+                    int count = args.NewItems.Count;
+                    if (args.NewStartingIndex > args.OldStartingIndex)
+                    {
+                        insertIndex = args.NewStartingIndex - count + 1;
+                    }
+                    else if (args.NewStartingIndex < args.OldStartingIndex)
+                    {
+                        insertIndex = args.NewStartingIndex;
+                    }
+                    else
+                    {
+                        insertIndex = args.OldStartingIndex;
+                    }
+
+                    for (var i = 0; i < count; i++)
+                    {
+                        var item = args.NewItems[i];
+                        if (Filter == null || PassesFilter(item))
+                        {
+                            ProcessAddEvent(item, insertIndex + i);
+                        }
+                    }
+                }
+                return;
+            }
+
             // fire notifications for removes
             if (args.OldItems != null &&
                 (args.Action == NotifyCollectionChangedAction.Remove ||
-                args.Action == NotifyCollectionChangedAction.Replace ||
-                args.Action == NotifyCollectionChangedAction.Move))
+                args.Action == NotifyCollectionChangedAction.Replace))
             {
                 foreach (var removedItem in args.OldItems)
                 {
-                    ProcessRemoveEvent(removedItem, args.Action != NotifyCollectionChangedAction.Remove);
+                    ProcessRemoveEvent(removedItem, args.Action == NotifyCollectionChangedAction.Replace);
                 }
             }
 
             // fire notifications for adds
             if (args.NewItems != null &&
                 (args.Action == NotifyCollectionChangedAction.Add ||
-                 args.Action == NotifyCollectionChangedAction.Replace ||
-                 args.Action == NotifyCollectionChangedAction.Move))
+                 args.Action == NotifyCollectionChangedAction.Replace))
             {
                 for (var i = 0; i < args.NewItems.Count; i++)
                 {
@@ -3469,8 +3510,7 @@ namespace Avalonia.Collections
                     }
                 }
             }
-            if (args.Action != NotifyCollectionChangedAction.Replace &&
-                args.Action != NotifyCollectionChangedAction.Move)
+            if (args.Action != NotifyCollectionChangedAction.Replace)
             {
                 OnPropertyChanged(nameof(ItemCount));
             }

--- a/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.cs
@@ -3444,20 +3444,22 @@ namespace Avalonia.Collections
             }
             
             // fire notifications for removes
-            if (args.OldItems != null && 
+            if (args.OldItems != null &&
                 (args.Action == NotifyCollectionChangedAction.Remove ||
-                args.Action == NotifyCollectionChangedAction.Replace))
+                args.Action == NotifyCollectionChangedAction.Replace ||
+                args.Action == NotifyCollectionChangedAction.Move))
             {
                 foreach (var removedItem in args.OldItems)
                 {
-                    ProcessRemoveEvent(removedItem, args.Action == NotifyCollectionChangedAction.Replace);
+                    ProcessRemoveEvent(removedItem, args.Action != NotifyCollectionChangedAction.Remove);
                 }
             }
 
             // fire notifications for adds
-            if (args.NewItems != null && 
+            if (args.NewItems != null &&
                 (args.Action == NotifyCollectionChangedAction.Add ||
-                 args.Action == NotifyCollectionChangedAction.Replace))
+                 args.Action == NotifyCollectionChangedAction.Replace ||
+                 args.Action == NotifyCollectionChangedAction.Move))
             {
                 for (var i = 0; i < args.NewItems.Count; i++)
                 {
@@ -3467,7 +3469,8 @@ namespace Avalonia.Collections
                     }
                 }
             }
-            if (args.Action != NotifyCollectionChangedAction.Replace)
+            if (args.Action != NotifyCollectionChangedAction.Replace &&
+                args.Action != NotifyCollectionChangedAction.Move)
             {
                 OnPropertyChanged(nameof(ItemCount));
             }

--- a/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.cs
@@ -3445,6 +3445,13 @@ namespace Avalonia.Collections
 
             if (args.Action == NotifyCollectionChangedAction.Move)
             {
+                int itemCount = args.OldItems?.Count ?? 0;
+                if (args.NewStartingIndex >= args.OldStartingIndex &&
+                    args.NewStartingIndex <= args.OldStartingIndex + itemCount - 1)
+                {
+                    return;
+                }
+
                 if (args.OldItems != null)
                 {
                     foreach (var removedItem in args.OldItems)
@@ -3455,23 +3462,17 @@ namespace Avalonia.Collections
 
                 if (args.NewItems != null)
                 {
-                    // Compute the correct insertion index in _internalList after
-                    // the moved items have been removed. args.NewStartingIndex is
-                    // in the original list's index space, so we adjust based on
-                    // the direction of the move.
                     int insertIndex;
                     int count = args.NewItems.Count;
                     if (args.NewStartingIndex > args.OldStartingIndex)
                     {
+                        // item(s) are being moved down
                         insertIndex = args.NewStartingIndex - count + 1;
-                    }
-                    else if (args.NewStartingIndex < args.OldStartingIndex)
-                    {
-                        insertIndex = args.NewStartingIndex;
                     }
                     else
                     {
-                        insertIndex = args.OldStartingIndex;
+                        // item(s) are being moved up
+                        insertIndex = args.NewStartingIndex;
                     }
 
                     for (var i = 0; i < count; i++)

--- a/src/Avalonia.Controls.DataGrid/DataGridDataConnection.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridDataConnection.cs
@@ -673,7 +673,7 @@ namespace Avalonia.Controls
                 // DataGridCollectionView.ProcessCollectionChanged converts Move into
                 // separate Remove+Add events which are handled by the cases above.
                 case NotifyCollectionChangedAction.Replace:
-                    throw new NotSupportedException(); //
+                    throw new NotSupportedException(); // 
 
                 case NotifyCollectionChangedAction.Reset:
                     // Did the data type change during the reset?  If not, we can recycle

--- a/src/Avalonia.Controls.DataGrid/DataGridDataConnection.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridDataConnection.cs
@@ -669,16 +669,9 @@ namespace Avalonia.Controls
                         }
                     }
                     break;
-                case NotifyCollectionChangedAction.Move:
-                    Debug.Assert(e.OldItems != null, "Unexpected NotifyCollectionChangedAction.Move notification");
-                    if (!IsGrouping)
-                    {
-                        // If we're grouping then we handle this through the CollectionViewGroup notifications
-                        Debug.Assert(e.OldItems.Count == 1);
-                        _owner.RemoveRowAt(e.OldStartingIndex, e.OldItems[0]);
-                        _owner.InsertRowAt(e.NewStartingIndex);
-                    }
-                    break;
+                // NotifyCollectionChangedAction.Move is not handled here.
+                // DataGridCollectionView.ProcessCollectionChanged converts Move into
+                // separate Remove+Add events which are handled by the cases above.
                 case NotifyCollectionChangedAction.Replace:
                     throw new NotSupportedException(); //
 

--- a/src/Avalonia.Controls.DataGrid/DataGridDataConnection.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridDataConnection.cs
@@ -669,8 +669,18 @@ namespace Avalonia.Controls
                         }
                     }
                     break;
+                case NotifyCollectionChangedAction.Move:
+                    Debug.Assert(e.OldItems != null, "Unexpected NotifyCollectionChangedAction.Move notification");
+                    if (!IsGrouping)
+                    {
+                        // If we're grouping then we handle this through the CollectionViewGroup notifications
+                        Debug.Assert(e.OldItems.Count == 1);
+                        _owner.RemoveRowAt(e.OldStartingIndex, e.OldItems[0]);
+                        _owner.InsertRowAt(e.NewStartingIndex);
+                    }
+                    break;
                 case NotifyCollectionChangedAction.Replace:
-                    throw new NotSupportedException(); // 
+                    throw new NotSupportedException(); //
 
                 case NotifyCollectionChangedAction.Reset:
                     // Did the data type change during the reset?  If not, we can recycle

--- a/src/Avalonia.Controls.DataGrid/DataGridRows.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRows.cs
@@ -2207,10 +2207,7 @@ namespace Avalonia.Controls
                     case NotifyCollectionChangedAction.Remove:
                         CollectionViewGroup_CollectionChanged_Remove(sender, e);
                         break;
-                    case NotifyCollectionChangedAction.Move:
-                        CollectionViewGroup_CollectionChanged_Remove(sender, e);
-                        CollectionViewGroup_CollectionChanged_Add(sender, e);
-                        break;
+                    // TODO: handle NotifyCollectionChangedAction.Move
                 }
             }
         }

--- a/src/Avalonia.Controls.DataGrid/DataGridRows.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRows.cs
@@ -2207,6 +2207,10 @@ namespace Avalonia.Controls
                     case NotifyCollectionChangedAction.Remove:
                         CollectionViewGroup_CollectionChanged_Remove(sender, e);
                         break;
+                    case NotifyCollectionChangedAction.Move:
+                        CollectionViewGroup_CollectionChanged_Remove(sender, e);
+                        CollectionViewGroup_CollectionChanged_Add(sender, e);
+                        break;
                 }
             }
         }

--- a/src/DataGridSample/DataGridPage.axaml
+++ b/src/DataGridSample/DataGridPage.axaml
@@ -153,6 +153,7 @@
                     IsEnabled="{Binding #dataGridMutations.SelectedItem, Converter={x:Static ObjectConverters.IsNotNull}}" />
             <Button Name="btnMutMoveUp" Content="Move Selection Up" />
             <Button Name="btnMutMoveDown" Content="Move Selection Down" />
+            <Button Name="btnMutMoveInPlace" Content="Move In Place" />
           </StackPanel>
         </Grid>
       </TabItem>

--- a/src/DataGridSample/DataGridPage.axaml
+++ b/src/DataGridSample/DataGridPage.axaml
@@ -136,6 +136,26 @@
           <Button Grid.Row="1" Name="btnAdd" Margin="12,0,12,12" Content="Add" HorizontalAlignment="Right" />
         </Grid>
       </TabItem>
+      <TabItem Header="Collection Mutations">
+        <Grid RowDefinitions="*,Auto">
+          <DataGrid Name="dataGridMutations" Grid.Row="0" Margin="12" IsReadOnly="True"
+                    ItemsSource="{Binding MutationsSource}">
+            <DataGrid.Columns>
+              <DataGridTextColumn Header="First Name" Binding="{Binding FirstName}" Width="2*" x:DataType="models:Person" />
+              <DataGridTextColumn Header="Last Name" Binding="{Binding LastName}" Width="2*" x:DataType="models:Person" />
+              <DataGridTextColumn Header="Age" Binding="{Binding Age}" Width="*" x:DataType="models:Person" />
+            </DataGrid.Columns>
+          </DataGrid>
+          <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="5" Margin="12,0,12,12" HorizontalAlignment="Right">
+            <Button Name="btnMutAdd" Content="Add" />
+            <Button Name="btnMutAddRange" Content="Add Range (3)" />
+            <Button Name="btnMutRemove" Content="Remove Selection"
+                    IsEnabled="{Binding #dataGridMutations.SelectedItem, Converter={x:Static ObjectConverters.IsNotNull}}" />
+            <Button Name="btnMutMoveUp" Content="Move Selection Up" />
+            <Button Name="btnMutMoveDown" Content="Move Selection Down" />
+          </StackPanel>
+        </Grid>
+      </TabItem>
     </TabControl>
   </Grid>
 </UserControl>

--- a/src/DataGridSample/DataGridPage.axaml.cs
+++ b/src/DataGridSample/DataGridPage.axaml.cs
@@ -185,7 +185,9 @@ namespace DataGridSample
             for (var i = 1; i < indices.Count; i++)
             {
                 if (indices[i] != indices[i - 1] + 1)
+                {
                     return (-1, 0);
+                }
             }
 
             return (indices[0], indices.Count);

--- a/src/DataGridSample/DataGridPage.axaml.cs
+++ b/src/DataGridSample/DataGridPage.axaml.cs
@@ -144,6 +144,20 @@ namespace DataGridSample
                 }
             };
 
+            var btnMoveInPlace = this.Get<Button>("btnMutMoveInPlace");
+            btnMoveInPlace.IsEnabled = false;
+            dgMutations.SelectionChanged += (s, e) =>
+            {
+                var (idx, cnt) = GetContiguousSelectionRange(dgMutations, mutationList);
+                btnMoveInPlace.IsEnabled = idx >= 0;
+            };
+            btnMoveInPlace.Click += (s, e) =>
+            {
+                var (firstIndex, count) = GetContiguousSelectionRange(dgMutations, mutationList);
+                if (firstIndex >= 0)
+                    mutationList.MoveRange(firstIndex, count, firstIndex);
+            };
+
             DataContext = this;
         }
 

--- a/src/DataGridSample/DataGridPage.axaml.cs
+++ b/src/DataGridSample/DataGridPage.axaml.cs
@@ -59,10 +59,103 @@ namespace DataGridSample
             var addButton = this.Get<Button>("btnAdd");
             addButton.Click += (a, b) => list.Add(new Person());
 
+            // Collection Mutations tab
+            var mutationCounter = 0;
+            var mutationList = new AvaloniaList<Person>
+            {
+                new Person { FirstName = "Alice", LastName = "Smith", Age = 25 },
+                new Person { FirstName = "Bob", LastName = "Jones", Age = 30 },
+                new Person { FirstName = "Carol", LastName = "White", Age = 35 },
+                new Person { FirstName = "Dave", LastName = "Brown", Age = 40 },
+                new Person { FirstName = "Eve", LastName = "Davis", Age = 45 },
+            };
+
+            MutationsSource = mutationList;
+
+            var dgMutations = this.Get<DataGrid>("dataGridMutations");
+
+            var btnMoveUp = this.Get<Button>("btnMutMoveUp");
+            var btnMoveDown = this.Get<Button>("btnMutMoveDown");
+            btnMoveUp.IsEnabled = false;
+            btnMoveDown.IsEnabled = false;
+            dgMutations.SelectionChanged += (s, e) =>
+            {
+                if (dgMutations.SelectedItems.Count == 1 && dgMutations.SelectedItem is Person sel)
+                {
+                    var index = mutationList.IndexOf(sel);
+                    btnMoveUp.IsEnabled = index > 0;
+                    btnMoveDown.IsEnabled = index < mutationList.Count - 1;
+                }
+                else
+                {
+                    btnMoveUp.IsEnabled = false;
+                    btnMoveDown.IsEnabled = false;
+                }
+            };
+
+            this.Get<Button>("btnMutAdd").Click += (s, e) =>
+            {
+                mutationCounter++;
+                mutationList.Add(new Person
+                {
+                    FirstName = $"New{mutationCounter}",
+                    LastName = $"Person{mutationCounter}",
+                    Age = 20 + mutationCounter
+                });
+            };
+
+            this.Get<Button>("btnMutAddRange").Click += (s, e) =>
+            {
+                mutationList.AddRange(Enumerable.Range(0, 3).Select(_ =>
+                {
+                    mutationCounter++;
+                    return new Person
+                    {
+                        FirstName = $"New{mutationCounter}",
+                        LastName = $"Person{mutationCounter}",
+                        Age = 20 + mutationCounter
+                    };
+                }));
+            };
+
+            this.Get<Button>("btnMutRemove").Click += (s, e) =>
+            {
+                var selected = dgMutations.SelectedItems.Cast<Person>().ToList();
+                mutationList.RemoveAll(selected);
+            };
+
+            this.Get<Button>("btnMutMoveUp").Click += (s, e) =>
+            {
+                if (dgMutations.SelectedItem is Person selectedItem)
+                {
+                    var index = mutationList.IndexOf(selectedItem);
+                    if (index > 0)
+                    {
+                        mutationList.Move(index, index - 1);
+                        dgMutations.SelectedItem = selectedItem;
+                    }
+                }
+            };
+
+            this.Get<Button>("btnMutMoveDown").Click += (s, e) =>
+            {
+                if (dgMutations.SelectedItem is Person selectedItem)
+                {
+                    var index = mutationList.IndexOf(selectedItem);
+                    if (index >= 0 && index < mutationList.Count - 1)
+                    {
+                        mutationList.Move(index, index + 1);
+                        dgMutations.SelectedItem = selectedItem;
+                    }
+                }
+            };
+
             DataContext = this;
         }
 
         public IEnumerable<Person> DataGrid3Source { get; }
+
+        public IEnumerable<Person> MutationsSource { get; }
 
         private void InitializeComponent()
         {

--- a/src/DataGridSample/DataGridPage.axaml.cs
+++ b/src/DataGridSample/DataGridPage.axaml.cs
@@ -80,17 +80,9 @@ namespace DataGridSample
             btnMoveDown.IsEnabled = false;
             dgMutations.SelectionChanged += (s, e) =>
             {
-                if (dgMutations.SelectedItems.Count == 1 && dgMutations.SelectedItem is Person sel)
-                {
-                    var index = mutationList.IndexOf(sel);
-                    btnMoveUp.IsEnabled = index > 0;
-                    btnMoveDown.IsEnabled = index < mutationList.Count - 1;
-                }
-                else
-                {
-                    btnMoveUp.IsEnabled = false;
-                    btnMoveDown.IsEnabled = false;
-                }
+                var (firstIndex, count) = GetContiguousSelectionRange(dgMutations, mutationList);
+                btnMoveUp.IsEnabled = firstIndex > 0;
+                btnMoveDown.IsEnabled = firstIndex >= 0 && firstIndex + count < mutationList.Count;
             };
 
             this.Get<Button>("btnMutAdd").Click += (s, e) =>
@@ -126,26 +118,28 @@ namespace DataGridSample
 
             this.Get<Button>("btnMutMoveUp").Click += (s, e) =>
             {
-                if (dgMutations.SelectedItem is Person selectedItem)
+                var (firstIndex, count) = GetContiguousSelectionRange(dgMutations, mutationList);
+                if (firstIndex > 0)
                 {
-                    var index = mutationList.IndexOf(selectedItem);
-                    if (index > 0)
-                    {
-                        mutationList.Move(index, index - 1);
-                        dgMutations.SelectedItem = selectedItem;
-                    }
+                    var selected = dgMutations.SelectedItems.Cast<Person>().ToList();
+                    mutationList.MoveRange(firstIndex, count, firstIndex - 1);
+                    dgMutations.SelectedItems.Clear();
+                    foreach (var item in selected)
+                        dgMutations.SelectedItems.Add(item);
                 }
             };
 
             this.Get<Button>("btnMutMoveDown").Click += (s, e) =>
             {
-                if (dgMutations.SelectedItem is Person selectedItem)
+                var (firstIndex, count) = GetContiguousSelectionRange(dgMutations, mutationList);
+                if (firstIndex >= 0 && firstIndex + count < mutationList.Count)
                 {
-                    var index = mutationList.IndexOf(selectedItem);
-                    if (index >= 0 && index < mutationList.Count - 1)
+                    var selected = dgMutations.SelectedItems.Cast<Person>().ToList();
+                    mutationList.MoveRange(firstIndex, count, firstIndex + count);
+                    dgMutations.SelectedItems.Clear();
+                    foreach (var item in selected)
                     {
-                        mutationList.Move(index, index + 1);
-                        dgMutations.SelectedItem = selectedItem;
+                        dgMutations.SelectedItems.Add(item);
                     }
                 }
             };
@@ -160,6 +154,23 @@ namespace DataGridSample
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
+        }
+
+        private static (int firstIndex, int count) GetContiguousSelectionRange(DataGrid grid, IList<Person> list)
+        {
+            var indices = grid.SelectedItems.Cast<Person>().Select(list.IndexOf).OrderBy(i => i).ToList();
+            if (indices.Count == 0)
+            {
+                return (-1, 0);
+            }
+
+            for (var i = 1; i < indices.Count; i++)
+            {
+                if (indices[i] != indices[i - 1] + 1)
+                    return (-1, 0);
+            }
+
+            return (indices[0], indices.Count);
         }
 
         private class ReversedStringComparer : IComparer<object>, IComparer

--- a/src/DataGridSample/DataGridPage.axaml.cs
+++ b/src/DataGridSample/DataGridPage.axaml.cs
@@ -125,7 +125,9 @@ namespace DataGridSample
                     mutationList.MoveRange(firstIndex, count, firstIndex - 1);
                     dgMutations.SelectedItems.Clear();
                     foreach (var item in selected)
+                    {
                         dgMutations.SelectedItems.Add(item);
+                    }
                 }
             };
 
@@ -155,7 +157,9 @@ namespace DataGridSample
             {
                 var (firstIndex, count) = GetContiguousSelectionRange(dgMutations, mutationList);
                 if (firstIndex >= 0)
+                {
                     mutationList.MoveRange(firstIndex, count, firstIndex);
+                }
             };
 
             DataContext = this;


### PR DESCRIPTION
# Fix DataGrid not updating on collection Move operations

## Summary
- Add `NotifyCollectionChangedAction.Move` handling to `DataGridCollectionView.ProcessCollectionChanged`, which translates Move events from the source collection into Remove+Add events that the DataGrid already knows how to process
- The insertion index is computed from the event args to account for `AvaloniaList.MoveRange` reporting `NewStartingIndex` in the original (pre-removal) index space
- No-op moves (where the target index falls within the moved block) are detected and skipped
- Move handling for grouped DataGrids and direct `NotifyingDataSource_CollectionChanged` is left as future work (marked with TODO comments)
- Add a "Collection Mutations" tab to the sample app to exercise Add, Add Range, Remove, Move Up/Down, and Move In Place operations against a DataGrid backed by an `AvaloniaList`

## Known limitations
- Grouped DataGrid scenarios (`CollectionViewGroup_CollectionChanged`) do not handle Move yet