### PR TITLE
Quick selection of rows in a table using list items or indexes

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridRows.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRows.cs
@@ -1993,30 +1993,24 @@ namespace Avalonia.Controls
             if (start > end)
                 yield break;
 
-            var s = nums[start];
-            var prev = s;
+            var beginIndex = nums[start];
+            var prevIndex = beginIndex;
             for (int i = start + 1; i <= end; i++)
             {
-                var v = nums[i];
-                if (prev == v)
+                var current = nums[i];
+                if (prevIndex == current)
                     continue;
-                if (prev != v - 1)
+                if (prevIndex != current - 1)
                 {
-                    if (prev > s)
-                    {
-                        yield return new(s, prev);
-                    }
-                    else
-                        yield return new(s, prev);
-                    s = v;
+                    yield return new(beginIndex, prevIndex);
+
+                    beginIndex = current;
                 }
-                prev = v;
+                prevIndex = current;
             }
 
-            if (prev > s)
-                yield return new(s, prev);
-            else
-                yield return new(s, prev);
+            if (prevIndex > beginIndex)
+                yield return new(beginIndex, prevIndex);
         }
 
         public void SelectItems(System.Collections.IList items)

--- a/src/Avalonia.Controls.DataGrid/DataGridRows.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRows.cs
@@ -1970,6 +1970,84 @@ namespace Avalonia.Controls
             }
         }
 
+        private IEnumerable<(int from, int to)> GetIdsRanges(IList<int> indexes)
+        {
+            if (indexes == null || indexes.Count == 0)
+                yield break;
+            var min = 0;
+            var max = DataConnection.List.Count - 1;
+
+            var nums = new int[indexes.Count];
+            indexes.CopyTo(nums, 0);
+            Array.Sort(nums);
+
+            int start = 0;
+            int end = nums.Length - 1;
+
+            while (nums[start] < min)
+                start++;
+
+            while (nums[end] > max)
+                end--;
+
+            if (start > end)
+                yield break;
+
+            var s = nums[start];
+            var prev = s;
+            for (int i = start + 1; i <= end; i++)
+            {
+                var v = nums[i];
+                if (prev == v)
+                    continue;
+                if (prev != v - 1)
+                {
+                    if (prev > s)
+                    {
+                        yield return new(s, prev);
+                    }
+                    else
+                        yield return new(s, prev);
+                    s = v;
+                }
+                prev = v;
+            }
+
+            if (prev > s)
+                yield return new(s, prev);
+            else
+                yield return new(s, prev);
+        }
+
+        public void SelectItems(System.Collections.IList items)
+        {
+            var indexes = new List<int>(items.Count);
+            foreach (var item in items)
+            {
+                var num = DataConnection.IndexOf(item);
+                if (num >= 0)
+                    indexes.Add(num);
+            }
+            Select(indexes);
+        }
+
+        public void Select(IList<int> rowIds)
+        {
+            try
+            {
+                _noSelectionChangeCount++;
+
+                foreach (var pair in GetIdsRanges(rowIds))
+                {
+                    SetRowsSelection(pair.from, pair.to);
+                }
+            }
+            finally
+            {
+                NoSelectionChangeCount--;
+            }
+        }
+
         private void UnloadElements(bool recycle)
         {
             // Since we're unloading all the elements, we can't be in editing mode anymore,


### PR DESCRIPTION
Quick selection of rows in a table by list items or indexes.
Two methods have been added:
- SelectItems(items) - quick selection by objects
- Select(indexes) - quick selection by object indexes

It's strange that no one has added this feature before.
The current implementation, which selects one item at a time, is very slow (taking minutes), especially when trying to select several thousand rows.

Решение довольно простое.  И позволяет быстро "восстановить" некое сохраненное состояние пользователя, там где хранится выборка к примеру.