### PR TITLE
[Fluent] Convert DataGrid ControlTheme dimension setters to DynamicResource

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
@@ -54,6 +54,11 @@
     <x:Double x:Key="ListAccentLowOpacity">0.6</x:Double>
     <x:Double x:Key="ListAccentMediumOpacity">0.8</x:Double>
     <x:Double x:Key="DataGridSortIconMinWidth">32</x:Double>
+    <Thickness x:Key="DataGridColumnHeaderPadding">12,0,0,0</Thickness>
+    <Thickness x:Key="DataGridCellPadding">0</Thickness>
+    <x:Double x:Key="DataGridCellFontSize">15</x:Double>
+    <x:Double x:Key="DataGridCellMinHeight">32</x:Double>
+    <x:Double x:Key="DataGridColumnHeaderFontSize">12</x:Double>
 
     <StreamGeometry x:Key="DataGridSortIconDescendingPath">M1875 1011l-787 787v-1798h-128v1798l-787 -787l-90 90l941 941l941 -941z</StreamGeometry>
     <StreamGeometry x:Key="DataGridSortIconAscendingPath">M1965 947l-941 -941l-941 941l90 90l787 -787v1798h128v-1798l787 787z</StreamGeometry>
@@ -85,8 +90,9 @@
       <Setter Property="Background" Value="{DynamicResource DataGridCellBackgroundBrush}" />
       <Setter Property="HorizontalContentAlignment" Value="Stretch" />
       <Setter Property="VerticalContentAlignment" Value="Stretch" />
-      <Setter Property="FontSize" Value="15" />
-      <Setter Property="MinHeight" Value="32" />
+      <Setter Property="FontSize" Value="{DynamicResource DataGridCellFontSize}" />
+      <Setter Property="MinHeight" Value="{DynamicResource DataGridCellMinHeight}" />
+      <Setter Property="Padding" Value="{DynamicResource DataGridCellPadding}" />
       <Setter Property="Template">
         <ControlTemplate>
           <Border x:Name="CellBorder"
@@ -162,9 +168,9 @@
       <Setter Property="HorizontalContentAlignment" Value="Stretch" />
       <Setter Property="VerticalContentAlignment" Value="Center" />
       <Setter Property="SeparatorBrush" Value="{DynamicResource DataGridGridLinesBrush}" />
-      <Setter Property="Padding" Value="12,0,0,0" />
-      <Setter Property="FontSize" Value="12" />
-      <Setter Property="MinHeight" Value="32" />
+      <Setter Property="Padding" Value="{DynamicResource DataGridColumnHeaderPadding}" />
+      <Setter Property="FontSize" Value="{DynamicResource DataGridColumnHeaderFontSize}" />
+      <Setter Property="MinHeight" Value="{DynamicResource DataGridCellMinHeight}" />
       <Setter Property="Template">
         <ControlTemplate>
           <Border x:Name="HeaderBorder"
@@ -414,8 +420,8 @@
     <ControlTheme x:Key="{x:Type DataGridRowGroupHeader}" TargetType="DataGridRowGroupHeader">
       <Setter Property="Foreground" Value="{DynamicResource DataGridRowGroupHeaderForegroundBrush}" />
       <Setter Property="Background" Value="{DynamicResource DataGridRowGroupHeaderBackgroundBrush}" />
-      <Setter Property="FontSize" Value="15" />
-      <Setter Property="MinHeight" Value="32" />
+      <Setter Property="FontSize" Value="{DynamicResource DataGridCellFontSize}" />
+      <Setter Property="MinHeight" Value="{DynamicResource DataGridCellMinHeight}" />
       <Setter Property="Template">
         <ControlTemplate x:DataType="collections:DataGridCollectionViewGroup">
           <DataGridFrozenGrid Name="PART_Root"


### PR DESCRIPTION
## Summary

- `DataGridCell`, `DataGridColumnHeader`, and `DataGridRowGroupHeader` ControlTheme setters contained hardcoded values for `FontSize`, `MinHeight`, and `Padding`. Because ControlTheme applies at priority 11 (StyleTheme) and Application.Styles at priority 9, theme consumers could not override these values.
- Extracted five dimension/padding values into named resource keys in `Themes/Fluent.xaml`: `DataGridCellFontSize` (15), `DataGridCellMinHeight` (32), `DataGridColumnHeaderFontSize` (12), `DataGridColumnHeaderPadding` (12,0,0,0), `DataGridCellPadding` (0).
- `DataGridRowGroupHeader` and `DataGridColumnHeader` share `DataGridCellMinHeight` and `DataGridCellFontSize` where the logical sizes are the same.
- No visual change when the keys are not overridden — all defaults are identical to the previous hardcoded literals.

## Root cause

ControlTheme setters applied at priority 11 silently win over user-defined Application.Styles values at priority 9. A consumer writing:

```xml
<Application.Resources>
  <x:Double x:Key="DataGridCellFontSize">13</x:Double>
</Application.Resources>
```

would have had no effect before this change. Converting to `{DynamicResource DataGridCellFontSize}` defers the lookup to runtime and lets the resource chain find the consumer-supplied value first.

## Test plan

- [ ] `dotnet build src/Avalonia.Controls.DataGrid` — no XAML parse errors or missing-key warnings
- [ ] Open the DataGrid sample and verify cell font size, column header font size, and row heights are visually identical to before
- [ ] Override test: add `<x:Double x:Key="DataGridCellFontSize">11</x:Double>` to `Application.Resources` and confirm all three DataGrid control types change font size globally
- [ ] Override test: add `<x:Double x:Key="DataGridCellMinHeight">48</x:Double>` and confirm DataGridCell, DataGridColumnHeader, and DataGridRowGroupHeader all grow to 48 px