### PR TITLE
Fix ScrollBar not reacting to ScrollViewer.AllowAutoHide property changes

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -2515,7 +2515,6 @@ namespace Avalonia.Controls
                 _hScrollBar.Orientation = Orientation.Horizontal;
                 _hScrollBar.IsVisible = false;
                 _hScrollBar.Scroll += HorizontalScrollBar_Scroll;
-                _hScrollBar.AllowAutoHide = this.GetValue(ScrollViewer.AllowAutoHideProperty);
             }
 
             if (_vScrollBar != null)
@@ -2532,7 +2531,6 @@ namespace Avalonia.Controls
                 _vScrollBar.Orientation = Orientation.Vertical;
                 _vScrollBar.IsVisible = false;
                 _vScrollBar.Scroll += VerticalScrollBar_Scroll;
-                _vScrollBar.AllowAutoHide = this.GetValue(ScrollViewer.AllowAutoHideProperty);
             }
 
             _topLeftCornerHeader = e.NameScope.Find<ContentControl>(DATAGRID_elementTopLeftCornerHeaderName);

--- a/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
@@ -549,6 +549,7 @@
                          Grid.Column="2"
                          Grid.Row="2" />
               <ScrollBar Name="PART_VerticalScrollbar"
+                         AllowAutoHide="{Binding Path=(ScrollViewer.AllowAutoHide), RelativeSource={RelativeSource TemplatedParent}}"
                          Orientation="Vertical"
                          Grid.Column="2"
                          Grid.Row="1"
@@ -559,6 +560,7 @@
                     ColumnDefinitions="Auto,*">
                 <Rectangle Name="PART_FrozenColumnScrollBarSpacer" />
                 <ScrollBar Name="PART_HorizontalScrollbar"
+                           AllowAutoHide="{Binding Path=(ScrollViewer.AllowAutoHide), RelativeSource={RelativeSource TemplatedParent}}"
                            Grid.Column="1"
                            Orientation="Horizontal"
                            Height="{DynamicResource ScrollBarSize}" />

--- a/src/Avalonia.Controls.DataGrid/Themes/Simple.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Simple.xaml
@@ -353,6 +353,7 @@
                          Grid.ColumnSpan="2"
                          Fill="{DynamicResource ThemeControlMidHighBrush}" />
               <ScrollBar Name="PART_VerticalScrollbar"
+                         AllowAutoHide="{Binding Path=(ScrollViewer.AllowAutoHide), RelativeSource={RelativeSource TemplatedParent}}"
                          Grid.Row="1"
                          Grid.Column="2"
                          Width="{DynamicResource ScrollBarThickness}"
@@ -363,6 +364,7 @@
                     ColumnDefinitions="Auto,*">
                 <Rectangle Name="PART_FrozenColumnScrollBarSpacer" />
                 <ScrollBar Name="PART_HorizontalScrollbar"
+                           AllowAutoHide="{Binding Path=(ScrollViewer.AllowAutoHide), RelativeSource={RelativeSource TemplatedParent}}"
                            Grid.Column="1"
                            Height="{DynamicResource ScrollBarThickness}"
                            Orientation="Horizontal" />

--- a/src/DataGridSample/DataGridPage.axaml
+++ b/src/DataGridSample/DataGridPage.axaml
@@ -29,7 +29,7 @@
           <StackPanel Orientation="Horizontal"
                       DockPanel.Dock="Top"
                       Spacing="5">
-            <CheckBox x:Name="AllowAutoHide" IsChecked="True" Content="Scroll Bar Allow Auto Hide"/>
+            <CheckBox x:Name="AllowAutoHide" IsChecked="True" Content="Allow Scroll Bar Auto Hide"/>
             <CheckBox x:Name="ShowGDP" IsChecked="True" Content="Toggle GDP Column Visibility"/>
             <TextBlock Text="GDP Width:" VerticalAlignment="Center"/>
             <NumericUpDown x:Name="GDPWidth"

--- a/src/DataGridSample/DataGridPage.axaml
+++ b/src/DataGridSample/DataGridPage.axaml
@@ -19,21 +19,17 @@
       <Setter Property="Background" Value="{Binding Path=GDP, Mode=OneWay, Converter={StaticResource GDPConverter}}" />
     </ControlTheme>
   </UserControl.Resources>
-  <Grid RowDefinitions="Auto,Auto,*">
+  <Grid RowDefinitions="Auto,*">
     <StackPanel Orientation="Vertical" Spacing="4" Grid.Row="0">
       <TextBlock Classes="h2">A control for displaying and interacting with a data source.</TextBlock>
     </StackPanel>
-    <StackPanel Grid.Row="1" Spacing="4" Orientation="Horizontal" IsVisible="{Binding #EditableTab.IsSelected}">
-      <TextBlock Text="FontSize:" VerticalAlignment="Center"/>
-      <Slider x:Name="FontSizeSlider" Minimum="5" Maximum="30" Value="14" Width="100" VerticalAlignment="Center" />
-      <CheckBox x:Name="IsThreeStateCheckBox" IsChecked="False" Content="IsThreeState"/>
-    </StackPanel>
-    <TabControl Grid.Row="2">
+    <TabControl Grid.Row="1">
       <TabItem Header="DataGrid">
         <DockPanel>
           <StackPanel Orientation="Horizontal"
                       DockPanel.Dock="Top"
                       Spacing="5">
+            <CheckBox x:Name="AllowAutoHide" IsChecked="True" Content="Scroll Bar Allow Auto Hide"/>
             <CheckBox x:Name="ShowGDP" IsChecked="True" Content="Toggle GDP Column Visibility"/>
             <TextBlock Text="GDP Width:" VerticalAlignment="Center"/>
             <NumericUpDown x:Name="GDPWidth"
@@ -44,7 +40,7 @@
                     Value="200"/>
           </StackPanel>
           <DataGrid Name="dataGrid1" Margin="12" CanUserResizeColumns="True" CanUserReorderColumns="True" CanUserSortColumns="True" HeadersVisibility="All"
-                    RowBackground="#1000">
+                    RowBackground="#1000" ScrollViewer.AllowAutoHide="{Binding #AllowAutoHide.IsChecked}">
             <DataGrid.Styles>
               <Style Selector="DataGridRow">
                 <Setter Property="Header" Value="{Binding $self.Index}"/>
@@ -111,9 +107,14 @@
         </DataGrid>
       </TabItem>
       <TabItem x:Name="EditableTab" Header="Editable">
-        <Grid RowDefinitions="*,Auto">
+        <Grid RowDefinitions="Auto,*,Auto">
+          <StackPanel Spacing="5" Orientation="Horizontal">
+            <TextBlock Text="FontSize:" VerticalAlignment="Center"/>
+            <Slider x:Name="FontSizeSlider" Minimum="5" Maximum="30" Value="14" Width="100" VerticalAlignment="Center" />
+            <CheckBox x:Name="IsThreeStateCheckBox" IsChecked="False" Content="IsThreeState"/>
+          </StackPanel>
           <!-- Example of columns inheriting the data type from the Items source -->
-          <DataGrid Name="dataGridEdit" Margin="12" Grid.Row="0"
+          <DataGrid Name="dataGridEdit" Margin="12" Grid.Row="1"
                     ItemsSource="{Binding DataGrid3Source}">
             <DataGrid.Columns>
               <DataGridTextColumn Header="First Name" Binding="{Binding FirstName}" Width="2*" FontSize="{Binding #FontSizeSlider.Value, Mode=OneWay}" />
@@ -133,7 +134,7 @@
               </DataGridTemplateColumn>
             </DataGrid.Columns>
           </DataGrid>
-          <Button Grid.Row="1" Name="btnAdd" Margin="12,0,12,12" Content="Add" HorizontalAlignment="Right" />
+          <Button Grid.Row="2" Name="btnAdd" Margin="12,0,12,12" Content="Add" HorizontalAlignment="Right" />
         </Grid>
       </TabItem>
     </TabControl>


### PR DESCRIPTION
Fixes an issue where ScrollBar.AllowAutoHide was not bound in the control template and was instead assigned in code.
﻿
This change moves the property propagation to a template binding, ensuring that updates to AllowAutoHide are correctly reflected by the internal scroll bars.