### PR TITLE
Fix null reference in DataGrid layout rounding scroll logic

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -3988,7 +3988,7 @@ namespace Avalonia.Controls
             _focusedObject = null;
             if (ContainsFocus)
             {
-                var focusedObject = TopLevel.GetTopLevel(this)?.FocusManager.GetFocusedElement() as Visual;               
+                var focusedObject = TopLevel.GetTopLevel(this)?.FocusManager.GetFocusedElement() as Visual;
                 var root = focusedObject?.GetVisualRoot();
                 var isPopup = root != null && root != this.GetVisualRoot();
                 var focusLeftDataGrid = !this.IsVisualAncestorOf(focusedObject);
@@ -4439,6 +4439,11 @@ namespace Avalonia.Controls
             }
             else
             {
+                if (IsColumnOutOfBounds(DisplayData.FirstDisplayedScrollingCol))
+                {
+                    return 0;
+                }
+
                 // The entire first column is displayed, show the entire previous column when the user clicks
                 // the left button
                 DataGridColumn previousColumn = ColumnsInternal.GetPreviousVisibleScrollingColumn(
@@ -4459,7 +4464,7 @@ namespace Avalonia.Controls
         // This is a method rather than a property to emphasize a calculation
         private double GetHorizontalSmallScrollIncrease()
         {
-            if (DisplayData.FirstDisplayedScrollingCol >= 0)
+            if (!IsColumnOutOfBounds(DisplayData.FirstDisplayedScrollingCol))
             {
                 return GetEdgedColumnWidth(ColumnsItemsInternal[DisplayData.FirstDisplayedScrollingCol]) - _negHorizontalOffset;
             }

--- a/src/Avalonia.Controls.DataGrid/DataGridColumns.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumns.cs
@@ -1026,15 +1026,24 @@ namespace Avalonia.Controls
                     {
                         Debug.Assert(_negHorizontalOffset == 0);
                         dataGridColumn = ColumnsInternal.GetPreviousVisibleScrollingColumn(ColumnsItemsInternal[firstDisplayedScrollingCol]);
-                        Debug.Assert(dataGridColumn != null);
-                        Debug.Assert(GetEdgedColumnWidth(dataGridColumn) > displayWidth - cx);
-                        firstDisplayedScrollingCol = dataGridColumn.Index;
-                        _negHorizontalOffset = GetEdgedColumnWidth(dataGridColumn) - displayWidth + cx;
-                        _horizontalOffset -= displayWidth - cx;
-                        visibleScrollingColumnsTmp++;
-                        invalidate = true;
-                        cx = displayWidth;
-                        Debug.Assert(_negHorizontalOffset == GetNegHorizontalOffsetFromHorizontalOffset(_horizontalOffset));
+                        if (dataGridColumn == null)
+                        {
+                            _horizontalOffset = 0;
+                            _negHorizontalOffset = 0;
+                            HorizontalAdjustment = 0;
+                            invalidate = true;
+                        }
+                        else
+                        {
+                            Debug.Assert(GetEdgedColumnWidth(dataGridColumn) > displayWidth - cx);
+                            firstDisplayedScrollingCol = dataGridColumn.Index;
+                            _negHorizontalOffset = GetEdgedColumnWidth(dataGridColumn) - displayWidth + cx;
+                            _horizontalOffset -= displayWidth - cx;
+                            visibleScrollingColumnsTmp++;
+                            invalidate = true;
+                            cx = displayWidth;
+                            Debug.Assert(_negHorizontalOffset == GetNegHorizontalOffsetFromHorizontalOffset(_horizontalOffset));
+                        }
                     }
 
                     // update the number of visible columns to the new reality
@@ -1058,12 +1067,19 @@ namespace Avalonia.Controls
                 {
                     Debug.Assert(firstDisplayedScrollingCol >= 0);
                     dataGridColumn = ColumnsItemsInternal[firstDisplayedScrollingCol];
+                    DataGridColumn lastDisplayedColumn = dataGridColumn;
                     for (int jump = 0; jump < jumpFromFirstVisibleScrollingCol; jump++)
                     {
                         dataGridColumn = ColumnsInternal.GetNextVisibleColumn(dataGridColumn);
                         Debug.Assert(dataGridColumn != null);
+                        if (dataGridColumn == null)
+                        {
+                            break;
+                        }
+
+                        lastDisplayedColumn = dataGridColumn;
                     }
-                    DisplayData.LastTotallyDisplayedScrollingCol = dataGridColumn.Index;
+                    DisplayData.LastTotallyDisplayedScrollingCol = lastDisplayedColumn.Index;
                 }
             }
             else

--- a/src/Avalonia.Controls.DataGrid/DataGridColumns.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumns.cs
@@ -1071,7 +1071,6 @@ namespace Avalonia.Controls
                     for (int jump = 0; jump < jumpFromFirstVisibleScrollingCol; jump++)
                     {
                         dataGridColumn = ColumnsInternal.GetNextVisibleColumn(dataGridColumn);
-                        Debug.Assert(dataGridColumn != null);
                         if (dataGridColumn == null)
                         {
                             break;


### PR DESCRIPTION
Fix a layout-rounding edge case in DataGrid.ComputeDisplayedColumns.
When UseLayoutRounding is enabled, column layout can differ slightly from the logical ActualWidth-based scrolling calculations due to pixel rounding. After resizing and maximizing the window, this can leave a small positive horizontal offset even though the first displayed scrolling column is already the first visible scrolling column.
In that state, GetPreviousVisibleScrollingColumn(...) correctly returns null, because there is no previous scrolling column. The existing code assumed a previous column must exist whenever _horizontalOffset > 0, which could lead to a null dereference.
This change handles that boundary condition explicitly. If no previous visible scrolling column exists, the grid clamps the horizontal offset state back to zero and marks the displayed column state as invalidated. Otherwise, it preserves the existing behavior for partially scrolling in the previous column.
This prevents a crash while keeping the scroll/display state consistent with the actual leftmost scrolling column.