### PR TITLE
Fix DataGridBoundColumn null path bindings

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridBoundColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridBoundColumn.cs
@@ -58,7 +58,7 @@ namespace Avalonia.Controls
                                 throw new InvalidOperationException("DataGridColumn doesn't support BindingMode.OneWayToSource. Use BindingMode.TwoWay instead.");
                             }
 
-                            var path = compiled.Path.ToString();
+                            var path = compiled.Path?.ToString();
                             if (!string.IsNullOrEmpty(path) && compiled.Mode == BindingMode.Default)
                             {
                                 compiled.Mode = BindingMode.TwoWay;
@@ -76,7 +76,7 @@ namespace Avalonia.Controls
                                 throw new InvalidOperationException("DataGridColumn doesn't support BindingMode.OneWayToSource. Use BindingMode.TwoWay instead.");
                             }
 
-                            var path = reflection.Path.ToString();
+                            var path = reflection.Path;
                             if (!string.IsNullOrEmpty(path) && reflection.Mode == BindingMode.Default)
                             {
                                 reflection.Mode = BindingMode.TwoWay;
@@ -140,7 +140,7 @@ namespace Avalonia.Controls
             if (OwningGrid != null && OwningGrid.DataConnection.DataType != null
                 && Header == null && Binding != null && Binding is BindingBase binding)
             {
-                var path = (binding as Binding)?.Path ?? (binding as CompiledBindingExtension)?.Path.ToString();
+                var path = (binding as Binding)?.Path ?? (binding as CompiledBindingExtension)?.Path?.ToString();
                 if (!string.IsNullOrWhiteSpace(path))
                 {
                     var header = OwningGrid.DataConnection.DataType.GetDisplayName(path);


### PR DESCRIPTION
- Fix `DataGridBoundColumn` handling for bindings without a path, such as `{Binding Converter=...}`.

- Avoid null-reference exceptions when checking binding paths for mode/header inference.

Fixes #247 