### PR TITLE
Fix null reference in DataGridRowGroupHeader.OnDetachedFromLogicalTree

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
@@ -474,7 +474,12 @@ namespace Avalonia.Controls
         protected override void OnDetachedFromLogicalTree(LogicalTreeAttachmentEventArgs e)
         {
             base.OnDetachedFromLogicalTree(e);
-            OwningGrid.RemoveReferenceFromCollectionViewGroup(RowGroupInfo.CollectionViewGroup);
+             
+            if (OwningGrid != null && RowGroupInfo?.CollectionViewGroup is { } collectionViewGroup)
+            {
+                OwningGrid.RemoveReferenceFromCollectionViewGroup(collectionViewGroup);
+            }
+
             OwningGrid = null;
         }
     }


### PR DESCRIPTION
Fixes a `NullReferenceException` that can occur when switching tabs containing a grouped `DataGrid`.

`DataGridRowGroupHeader.OnDetachedFromLogicalTree` now checks that `OwningGrid` and `RowGroupInfo.CollectionViewGroup` are available before removing the collection view group reference.

Fixes #250 